### PR TITLE
Support NF4 V2 Model

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ def copy_quant_state(state: QuantState, device: torch.device = None) -> QuantSta
         else None
     )
 
-    return QuantState(
+    quant_state = QuantState(
         absmax=state.absmax.to(device),
         shape=state.shape,
         code=state.code.to(device),
@@ -47,6 +47,11 @@ def copy_quant_state(state: QuantState, device: torch.device = None) -> QuantSta
         state2=state2,
     )
 
+    # Manually add chunk_64_norm as an attribute if it exists
+    if hasattr(state, 'chunk_64_norm'):
+        quant_state.chunk_64_norm = state.chunk_64_norm.to(device)
+
+    return quant_state
 
 class ForgeParams4bit(Params4bit):
     def to(self, *args, **kwargs):
@@ -65,6 +70,11 @@ class ForgeParams4bit(Params4bit):
                 bnb_quantized=self.bnb_quantized,
                 module=self.module
             )
+
+            # Manually copy chunk_64_norm if it exists
+            if hasattr(self.quant_state, 'chunk_64_norm'):
+                n.quant_state.chunk_64_norm = self.quant_state.chunk_64_norm
+
             self.module.quant_state = n.quant_state
             self.data = n.data
             self.quant_state = n.quant_state


### PR DESCRIPTION
This change implements support for the nf4 V2 recommended model from [lllyasviel/flux1-dev-bnb-nf4](https://huggingface.co/lllyasviel/flux1-dev-bnb-nf4/blob/main/flux1-dev-bnb-nf4-v2.safetensors)

For me, the nf4 model gives significantly higher inference speeds compared to the GGUF quantized models (20-25%faster). This change allows using the newest "V2" version too.

Quick comparison for my case:
1024x1024 t2i:
- flux1-dev-bnb-nf4: 2.86 s/it
- flux1-dev-bnb-nf4-v2: 3.11 s/it
- flux1-dev-Q4_1: 4.18 s/it

In my test, sampling was fastest on the nf4 v1 model.